### PR TITLE
Add support for Thunderbird 128

### DIFF
--- a/manifest.json
+++ b/manifest.json
@@ -1,7 +1,7 @@
 {
   "manifest_version": 2,
   "name": "Toggle Headers",
-  "version": "3.0",
+  "version": "4.0",
   "author": "Matthias Schoettle",
   "homepage_url": "https://mattsch.com",
   "description": "__MSG_extensionDescription__",
@@ -9,7 +9,7 @@
   "applications": {
     "gecko": {
       "id": "toggle-headers@mattsch.com",
-      "strict_min_version": "74.0"
+      "strict_min_version": "128.0"
     }
   },
   "experiment_apis": {

--- a/toggle-headers.js
+++ b/toggle-headers.js
@@ -1,5 +1,6 @@
-var { ExtensionCommon } = ChromeUtils.import("resource://gre/modules/ExtensionCommon.jsm");
-var { Services } = ChromeUtils.import("resource://gre/modules/Services.jsm");
+var { ExtensionCommon } = ChromeUtils.importESModule(
+  "resource://gre/modules/ExtensionCommon.sys.mjs"
+);
 
 var toggleHeadersApi = class extends ExtensionCommon.ExtensionAPI {
   getAPI(context) {
@@ -23,17 +24,6 @@ var toggleHeadersApi = class extends ExtensionCommon.ExtensionAPI {
           // Switch from all to normal headers.
           else if (currentHeaderSetting == 2) {
             window.goDoCommand('cmd_viewNormalHeader');
-          }
-
-          // Get all current windows to reload the message in them.
-          let windows = Services.wm.getEnumerator(null)
-          while (windows.hasMoreElements()) {
-            let currentWindow = windows.getNext()
-            
-            // The main window has already been reloaded.
-            if (currentWindow != window) {
-              currentWindow.ReloadMessage();
-            }
           }
         },
       }


### PR DESCRIPTION
Support the latest Thunderbird release (v128).

* Adjusts how extension common is imported
* Removes logic to reload all windows since it is now done automatically when switching headers

Thanks to John Bieling from the Thunderbird Add-Ons team for this contribution.